### PR TITLE
allow disabling waiting-at-signal-multiplier

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -117,7 +117,7 @@ data:extend {
         name = "picker-waiting-at-signal-multiplier",
         setting_type = "startup",
         default_value = 0.1,
-        minimum_value = 0.001,
+        minimum_value = 0,
         maximum_value = 100,
         order = '[startup]-a-[penalty]-j'
       }


### PR DESCRIPTION
In stackers holding 3 or more trains in one line disabling waiting-at-signal-multiplier is a must.
Otherwise penalty, no matter how tiny the multiplier, will aggregate to the point where trains in front prevent any train form ever queuing up behind it even if there is ample space.
