### PR TITLE
Performance boost when safer trains is disabled

### DIFF
--- a/scripts/vehicles.lua
+++ b/scripts/vehicles.lua
@@ -352,19 +352,19 @@ if settings.startup['picker-manual-train-keys'].value then
     Event.register(keys, set_to_manual)
 end
 
-local function get_out_of_the_way(event)
-    local entity = event.entity
-    if entity.type == 'character' and event.cause and event.cause.train then
-        if event.cause.force == entity.force and settings.global['picker-get-out-of-the-way'].value then
-            local pos = entity.surface.find_non_colliding_position('character', event.cause.position, 5, 0.5)
-            if pos then
-                entity.teleport(pos)
-                if entity.health == 0 then
-                    entity.health = 1
-                end
-                casey_jones(event)
-            end
-        end
-    end
+if settings.startup['picker-get-out-of-the-way'].value then
+	local function get_out_of_the_way(event)
+		local entity = event.entity
+		if entity.type == 'character' and event.cause and event.cause.train and event.cause.force == entity.force then
+			local pos = entity.surface.find_non_colliding_position('character', event.cause.position, 5, 0.5)
+			if pos then
+				entity.teleport(pos)
+				if entity.health == 0 then
+					entity.health = 1
+				end
+				casey_jones(event)
+			end
+		end
+	end
+	Event.register(defines.events.on_entity_damaged, get_out_of_the_way)
 end
-Event.register(defines.events.on_entity_damaged, get_out_of_the_way)

--- a/settings.lua
+++ b/settings.lua
@@ -193,7 +193,7 @@ data:extend {
     {
         type = 'bool-setting',
         name = 'picker-get-out-of-the-way',
-        setting_type = 'runtime-global',
+        setting_type = 'startup',
         default_value = false,
         order = '[startup]-e-[automatic-trains]-c'
     }


### PR DESCRIPTION
The safer trains feature is very cpu intensive during big attack waves. Even registering an empty function to the `on_entity_damaged` event has a huge cpu impact.

This PR solves this by making the feature toggle a startup setting and only registering the event when needed